### PR TITLE
Audio fix

### DIFF
--- a/.idea/runConfigurations/dart_server__Flutter_.xml
+++ b/.idea/runConfigurations/dart_server__Flutter_.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="dart_server (Flutter)" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/packages/dart_server/lib/src/dart_server.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
+import 'package:universal_platform/universal_platform.dart'
+    show UniversalPlatform;
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -19,7 +19,7 @@ final Simulator simulator = Simulator();
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  if (Platform.isWindows) {
+  if (UniversalPlatform.isWindows) {
     await windowManager.ensureInitialized();
 
     WindowOptions windowOptions = const WindowOptions(

--- a/lib/server_connection_details.dart
+++ b/lib/server_connection_details.dart
@@ -1,12 +1,13 @@
 /// Details that the dart_server will use to instantiate itself.
 library;
 
-// TODO switch scheme to (secure) 'wss'
-import 'dart:io';
+import 'package:universal_platform/universal_platform.dart';
 
+// TODO switch scheme to (secure) 'wss'
 const String serverScheme = 'ws';
 
-final String serverHost = Platform.isWindows ? 'localhost' : '192.168.1.201';
+final String serverHost =
+    UniversalPlatform.isDesktopOrWeb ? 'localhost' : '192.168.1.201';
 
 const int serverPort = 5678;
 

--- a/lib/src/application/audio.dart
+++ b/lib/src/application/audio.dart
@@ -1,6 +1,8 @@
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 
+// TODO remove this file.
+
 /// Simple example of playing audio.
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/src/application/audio_player.dart
+++ b/lib/src/application/audio_player.dart
@@ -1,14 +1,26 @@
-import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:minisound/engine.dart' as minisound;
+import 'package:minisound/engine_flutter.dart';
 
+/// Simple class to handle playing of audio, e.g. weapon sound effects.
 class SoundPlayer {
   const SoundPlayer();
 
-  void play(String path) {
+  void play(String path) async {
     debugPrint('Playing $path');
 
-    // TODO convert to just_audio package that might be more reliable - see https://suragch.medium.com/playing-short-audio-clips-in-flutter-with-just-audio-3c80eb7eb6ea
-    final player = AudioPlayer();
-    player.play(AssetSource(path));
+    final engine = minisound.Engine();
+
+    // Engine initialization
+    // You can pass `periodMs` as an argument, to change determines the latency (does not affect web). Can cause crackles if too low.
+    await engine.init();
+
+    // For web, this should be executed after the first user interaction due to browsers' autoplay policy
+    await engine.start();
+
+    // Load the sound effect into the Engine.
+    final LoadedSound sound = await engine.loadSoundAsset(path);
+
+    sound.play();
   }
 }

--- a/lib/src/application/ship_systems/weapons.dart
+++ b/lib/src/application/ship_systems/weapons.dart
@@ -5,7 +5,7 @@ import 'ship_systems.dart';
 final class Weapons extends ShipSystem {
   Weapons() : super(dataHandlerFunction: _dataHandler);
 
-  static const String soundFilePath = 'sounds/files/weapons';
+  static const String soundFilePath = 'assets/sounds/files/weapons';
 
   EnemyShip? target;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,8 @@ dependencies:
   window_manager: ^0.4.3
   shelf: ^1.4.2
   shelf_web_socket: ^3.0.0
+  universal_platform: ^1.1.0
+  minisound: ^2.0.2
 
 
 dev_dependencies:
@@ -64,8 +66,8 @@ dev_dependencies:
 # The following section is specific to Flutter packages.
 flutter:
 
-#  assets:
-#    - assets/sounds/files/
+  assets:
+    - packages/dart_server/assets/sounds/files/
 #    - assets/
 #    - assets/sounds/
 #    - assets/sounds/files/weapons/


### PR DESCRIPTION
Fixes audio playing in `SoundPlayer` by using [`minisound`](https://pub.dev/packages/minisound) package instead of previous [`audioplayers`](https://pub.dev/packages/audioplayers). Completes #27 .